### PR TITLE
Use include and filter params from endpoints adapter

### DIFF
--- a/app/adapters/index.js
+++ b/app/adapters/index.js
@@ -1,0 +1,11 @@
+import adapter from 'ember-data-endpoints/adapter';
+
+export default adapter.extend({
+    host: '',
+    queryParams: {
+      include: 'chapters',
+      filter: {
+        published_after: '1990-01-01'
+      }
+    }
+});

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -2,12 +2,6 @@ import Ember from 'ember';
 
 export default Ember.Route.extend({
   model: function() {
-    return this.store.find('book', {
-      include: "chapters",
-        //'filter[published_after]': '1990-01-01'
-      filter: {
-        published_after: '1990-01-01'
-      }
-    });
+    return this.store.find('book');
   }
 });

--- a/tests/unit/adapters/index-test.js
+++ b/tests/unit/adapters/index-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('adapter:index', 'Unit | Adapter | index', {
+  // Specify the other units that are required for this test.
+  // needs: ['serializer:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  var adapter = this.subject();
+  assert.ok(adapter);
+});


### PR DESCRIPTION
Ref endpoints/ember-data-endpoints#10

@bmac 

It would be also interesting to have the filter param here.

The filter param would be good to exist both on route and adapter, but include can live only on the adapter.
